### PR TITLE
Monmsg implementation

### DIFF
--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -107,6 +107,10 @@
 
        gFails   = 0;
        
+       Print('***************************');
+       Print('Relic Package Manager Started');
+       Print(*Blank);
+       
        If (gSTMF);
          gSTMF = LOG_Prepare();
          If (gSTMF = *Off);
@@ -130,6 +134,9 @@
        If (gSTMF);
          LOG_Close();
        Endif;
+       
+       Print(*Blank);
+       Print('***************************');
        
        Return;
 
@@ -306,6 +313,7 @@
                  When (gMode = '*MONMSG');
                    lMonMsg = %Lookup(*Blank:gMonMsg);
                
+                   //If there is space, add it to the monmsg array list
                    If (lMonMsg > 0);
                      gMonMsg(lMonMsg) = lBuild;
                    Else;

--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -107,6 +107,7 @@
 
        gFails   = 0;
        
+       Print(*Blank);
        Print('***************************');
        Print('Relic Package Manager Started');
        Print(*Blank);
@@ -137,6 +138,7 @@
        
        Print(*Blank);
        Print('***************************');
+       Print(*Blank);
        
        Return;
 

--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -307,7 +307,7 @@
                    lMonMsg = %Lookup(*Blank:gMonMsg);
                
                    If (lMonMsg > 0);
-                     gMonMsg(lMonMsg) = lBuild
+                     gMonMsg(lMonMsg) = lBuild;
                    Else;
                      Print( 'Unable to monitor "' + lBuild + '". Max capaticy '
                           + 'for monitors hit.');   

--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -344,10 +344,12 @@
          Monitor;
            If (Cmd(pCmd) = 1);
            
-             If (%Lookup(errmsgid:gMonMsg));
+             //If the error is not in the monmsg list
+             //then do display it
+             If (%Lookup(errmsgid:gMonMsg) = 0);
                gFails += 1;
                Print(*Blank);
-               Print('ERROR: '%TrimR(%Subst(pCmd:1:52)) + ' ...');
+               Print('ERROR: ' + %TrimR(%Subst(pCmd:1:52)) + ' ...');
                Print('> ' + errmsgid);
                Print(*Blank);
              Endif;

--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -9,7 +9,7 @@
        dcl-pr Cmd int(10) extproc('system');
          cmdstring pointer value options(*string);
        end-pr;
-       Dcl-s errmsgid char(7) import('_EXCP_MSGID');
+       Dcl-s errmsgid char(7)        import('_EXCP_MSGID');
 
        Dcl-Pr printf Int(10) ExtProc('printf');
          format Pointer Value Options(*String);
@@ -56,9 +56,10 @@
        Dcl-C gRepoZip  'REPO.ZIP';
        Dcl-S gUser     Char(10)     Inz(*User);
 
-       Dcl-S IFSLINK   Varchar(256); //Ending with /
+       Dcl-S IFSLINK   Varchar(256);
        Dcl-s INTOLIB   Char(10);
 
+       Dcl-S gMonMsg  Like(errmsgid) Dim(48);
        Dcl-S gSTMF  Ind;      //*On if output to streamfile
        Dcl-S gMode  Char(10); //Used for scanning build file
        Dcl-S gFails Int(3);
@@ -185,6 +186,7 @@
          Dcl-S lBuild   Varchar(CMD_LEN);
          Dcl-S lComment Ind;
          Dcl-S lComTxt  Char(2);
+         Dcl-S lMonMsg  Int(3);
 
          gPackage.Name = %Trim(pNewDir);
          gPackage.Ver  = '1';
@@ -286,6 +288,9 @@
              when (lBuild = 'licenses:');
                Print('License mode currently not supported.');
                gMode = '*LIC';
+               
+             When (lBuild = 'monmsg:');
+               gMode = '*MONMSG';
 
              When (lBuild = 'build:');
                gMode = '*BUILD';
@@ -297,6 +302,15 @@
 
                  When (gMode = '*VER');
                    gPackage.Ver = %Trim(lBuild);
+                   
+                 When (gMode = '*MONMSG');
+                   lMonMsg = %Lookup(*Blank:gMonMsg);
+               
+                   If (lMonMsg > 0);
+                     gMonMsg(lMonMsg) = lBuild
+                   Else;
+                     Print('Unable to monitor "' + lBuild + '". Max capaticy for monitors hit.');
+                   Endif;
 
                  When (gMode = '*BUILD');
                    BUILD_Command(lBuild);
@@ -328,15 +342,26 @@
 
          Monitor;
            If (Cmd(pCmd) = 1);
-             gFails += 1;
-             Print(%Subst(pCmd:1:52) + ' ...');
-             Print('> ' + errmsgid);
-             Print(*Blank);
+           
+             If (%Lookup(errmsgid:gMonMsg));
+               gFails += 1;
+               Print(*Blank);
+               Print('ERROR: '%TrimR(%Subst(pCmd:1:52)) + ' ...');
+               Print('> ' + errmsgid);
+               Print(*Blank);
+             Endif;
+           
+           Else;
+           
+             Print(%TrimR(%Subst(pCmd:1:24)) + ' ... successful.');
+           
            ENDIF;
          On-Error *All;
            gFails += 1;
+           Print(*Blank);
            Print(%Subst(pCmd:1:52) + ' ...');
-           Print('> Caused program crash');
+           Print( '> Caused program crash. See job log for '
+                + 'possible information.');
            Print(*Blank);
          Endmon;
        END-PROC;

--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -309,7 +309,8 @@
                    If (lMonMsg > 0);
                      gMonMsg(lMonMsg) = lBuild
                    Else;
-                     Print('Unable to monitor "' + lBuild + '". Max capaticy for monitors hit.');
+                     Print( 'Unable to monitor "' + lBuild + '". Max capaticy '
+                          + 'for monitors hit.');   
                    Endif;
 
                  When (gMode = '*BUILD');


### PR DESCRIPTION
Feature request created from issue #14 

This implemented something similar to CLs `monmsg`. Anything error code noted in the `monmsg` section will be ignored if it occurs during the build stage.